### PR TITLE
drop column and adjust renaming

### DIFF
--- a/oil-gas-prices/oil-gas-prices.ipynb
+++ b/oil-gas-prices/oil-gas-prices.ipynb
@@ -236,9 +236,10 @@
    "source": [
     "def yearlyAverage(df):\n",
     "    df[\"Year\"] = pd.to_datetime(df[\"REF_DATE\"]).dt.year\n",
+    "    df = df.drop(columns=[\"REF_DATE\"])\n",
     "    yearlyAvg = df.groupby([\"Year\",\"GEO\"]).mean()\n",
     "    price_yearly = yearlyAvg.sort_values(by=[\"Year\"])\n",
-    "    price_yearly = price_yearly.rename(columns = {\"GEO\":\"Province\", \"Value\":\"Price\"})\n",
+    "    price_yearly.rename(columns = {\"Value\":\"Price\"}, inplace=True)\n",
     "    price_yearly = price_yearly.reset_index()\n",
     "    return price_yearly\n",
     "\n",


### PR DESCRIPTION
- patch error that was associated with column `REF_DATE` that isn't used after conversion
- change column renaming so that only `VALUE` column is renamed as other column `GEO` is renamed later in the notebook