### PR TITLE
Costliest Natural Disasters Notebook Fix

### DIFF
--- a/costliest-disasters/costliest-natural-disasters.ipynb
+++ b/costliest-disasters/costliest-natural-disasters.ipynb
@@ -378,8 +378,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.loc[:, 'EVENT START DATE'] = pd.to_datetime(data['EVENT START DATE'], format='%Y-%m-%d', errors='coerce')\n",
-    "data.loc[:, 'EVENT END DATE'] = pd.to_datetime(data['EVENT END DATE'], format='%Y-%m-%d', errors='coerce')\n",
+    "data.loc[:, 'EVENT START DATE'] = pd.to_datetime(data['EVENT START DATE'], format='%m/%d/%Y %I:%M:%S %p')\n",
+    "data.loc[:, 'EVENT END DATE'] = pd.to_datetime(data['EVENT END DATE'], format='%m/%d/%Y %I:%M:%S %p')\n",
+    "\n",
     "print(type(data['EVENT START DATE'].iloc[0]))\n",
     "print(type(data['EVENT END DATE'].iloc[3]))"
    ]

--- a/costliest-disasters/costliest-natural-disasters.ipynb
+++ b/costliest-disasters/costliest-natural-disasters.ipynb
@@ -5,7 +5,9 @@
    "id": "b2538929-5e56-4a7d-a8fb-cd4ff4a68110",
    "metadata": {},
    "source": [
-    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)"
+    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)\n",
+    "\n",
+    "<a href=\"https://hub.callysto.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcallysto%2Fdata-viz-of-the-week&branch=main&subPath=costliest-disasters/costliest-natural-disasters.ipynb&depth=1\" target=\"_parent\"><img src=\"https://raw.githubusercontent.com/callysto/curriculum-notebooks/master/open-in-callysto-button.svg?sanitize=true\" width=\"123\" height=\"24\" alt=\"Open in Callysto\"></a>"
    ]
   },
   {

--- a/costliest-disasters/costliest-natural-disasters.ipynb
+++ b/costliest-disasters/costliest-natural-disasters.ipynb
@@ -376,8 +376,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data['EVENT START DATE'] = pd.to_datetime(data['EVENT START DATE'], dayfirst=True, errors='coerce')\n",
-    "data['EVENT END DATE'] = pd.to_datetime(data['EVENT END DATE'], dayfirst=True, errors='coerce')\n",
+    "data.loc[:, 'EVENT START DATE'] = pd.to_datetime(data['EVENT START DATE'], format='%Y-%m-%d', errors='coerce')\n",
+    "data.loc[:, 'EVENT END DATE'] = pd.to_datetime(data['EVENT END DATE'], format='%Y-%m-%d', errors='coerce')\n",
     "print(type(data['EVENT START DATE'].iloc[0]))\n",
     "print(type(data['EVENT END DATE'].iloc[3]))"
    ]
@@ -621,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
- fixed user-warning by using `.loc` for datetimes instead of `iloc`