### PR TITLE
Wildfires notebook fixes

### DIFF
--- a/wildfires/wildfires.ipynb
+++ b/wildfires/wildfires.ipynb
@@ -5,7 +5,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)"
+    "![Callysto.ca Banner](https://github.com/callysto/curriculum-notebooks/blob/master/callysto-notebook-banner-top.jpg?raw=true)\n",
+    "\n",
+    "<a href=\"https://hub.callysto.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcallysto%2Fdata-viz-of-the-week&branch=main&subPath=wildfires/wildfires.ipynb&depth=1\" target=\"_parent\"><img src=\"https://raw.githubusercontent.com/callysto/curriculum-notebooks/master/open-in-callysto-button.svg?sanitize=true\" width=\"123\" height=\"24\" alt=\"Open in Callysto\"/></a>"
    ]
   },
   {

--- a/wildfires/wildfires.ipynb
+++ b/wildfires/wildfires.ipynb
@@ -120,6 +120,8 @@
     "import plotly_express as px\n",
     "from plotly.subplots import make_subplots\n",
     "import matplotlib.pyplot as plt\n",
+    "import matplotlib.colors\n",
+    "\n",
     "print(\"Libaries imported\")"
    ]
   },
@@ -202,15 +204,16 @@
    "source": [
     "years = list(range(1990, 2022))\n",
     "\n",
-    "# Generate a diverging color scheme from red to blue\n",
-    "color_scheme = plt.cm.get_cmap('RdYlBu', len(years))\n",
+    "# red to blue colour scheme\n",
+    "color_scheme = plt.get_cmap('RdYlBu', len(years))\n",
     "\n",
     "color_map = {}\n",
     "\n",
     "for i, year in enumerate(years):\n",
-    "    color = color_scheme(i)\n",
-    "    hex_color = '#{:02x}{:02x}{:02x}'.format(int(color[0]*255), int(color[1]*255), int(color[2]*255))\n",
+    "    color = color_scheme(i / (len(years) - 1))\n",
+    "    hex_color = matplotlib.colors.to_hex(color)\n",
     "    color_map[year] = hex_color\n",
+    "\n",
     "print(color_map)"
    ]
   },


### PR DESCRIPTION
- fixed matplotlib depreciation warning using `matplotlib.colors` instead of `get_cmap` function
- added callysto button